### PR TITLE
Getting the front-end runnable 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 .DS_Store
 node_modules
 /build
-/.svelte-kit
+svelte-kit
 /package
 .env
 .env.*

--- a/frontend/src/routes/index.svelte
+++ b/frontend/src/routes/index.svelte
@@ -3,7 +3,6 @@
 </script>
 
 <script>
-	import Counter from '$lib/Counter.svelte';
 </script>
 
 <svelte:head>
@@ -25,8 +24,6 @@
 	<h2>
 		try editing <strong>src/routes/index.svelte</strong>
 	</h2>
-
-	<Counter />
 </section>
 
 <style>


### PR DESCRIPTION
## Why? 
I noticed I was getting errors when I tried to run `npm run dev` on my newly cloned repo, so I made the minimum amount of edits to get it runnable. 

## Edits
#### Edit 1
There was a reference to what I believe was a default project file (Counter.svelte), which doesn't exist. I removed the reference. 

#### Edit 2
I also noticed that the .gitignore only ignores the "svelte-kit" package in the root folder, but the `npm install` on local will cause that package to be installed in other folders as well. We probably don't want that mixed into our commits, so I just made it universally ignored. 